### PR TITLE
Ignore prefix

### DIFF
--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -284,7 +284,9 @@ class ConvertLayout(Encoder):
     def encode(self,
                data: mx.sym.Symbol,
                data_length: Optional[mx.sym.Symbol],
-               seq_len: int) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, int]:
+               seq_len: int,
+               source: Optional[mx.sym.Symbol],
+               separator_id: int = None) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, int]:
         """
         Encodes data given sequence lengths of individual examples and maximum sequence length.
 
@@ -871,7 +873,9 @@ class RecurrentEncoder(Encoder):
     def encode(self,
                data: mx.sym.Symbol,
                data_length: Optional[mx.sym.Symbol],
-               seq_len: int) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, int]:
+               seq_len: int,
+               source: Optional[mx.sym.Symbol],
+               separator_id: int = None) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, int]:
         """
         Encodes data given sequence lengths of individual examples and maximum sequence length.
 
@@ -953,7 +957,9 @@ class BiDirectionalRNNEncoder(Encoder):
     def encode(self,
                data: mx.sym.Symbol,
                data_length: mx.sym.Symbol,
-               seq_len: int) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, int]:
+               seq_len: int,
+               source: Optional[mx.sym.Symbol],
+               separator_id: int = None) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, int]:
         """
         Encodes data given sequence lengths of individual examples and maximum sequence length.
 
@@ -964,12 +970,12 @@ class BiDirectionalRNNEncoder(Encoder):
         """
         if self.layout[0] == 'N':
             data = mx.sym.swapaxes(data=data, dim1=0, dim2=1)
-        data = self._encode(data, data_length, seq_len)
+        data = self._encode(data, data_length, seq_len, source, separator_id)
         if self.layout[0] == 'N':
             data = mx.sym.swapaxes(data=data, dim1=0, dim2=1)
         return data, data_length, seq_len
 
-    def _encode(self, data: mx.sym.Symbol, data_length: mx.sym.Symbol, seq_len: int) -> mx.sym.Symbol:
+    def _encode(self, data: mx.sym.Symbol, data_length: mx.sym.Symbol, seq_len: int, source: Optional[mx.sym.Symbol], separator_id: int = None) -> mx.sym.Symbol:
         """
         Bidirectionally encodes time-major data.
         """
@@ -977,9 +983,9 @@ class BiDirectionalRNNEncoder(Encoder):
         data_reverse = mx.sym.SequenceReverse(data=data, sequence_length=data_length,
                                               use_sequence_length=True)
         # (seq_length, batch, cell_num_hidden)
-        hidden_forward, _, _ = self.forward_rnn.encode(data, data_length, seq_len)
+        hidden_forward, _, _ = self.forward_rnn.encode(data, data_length, seq_len, source, separator_id)
         # (seq_length, batch, cell_num_hidden)
-        hidden_reverse, _, _ = self.reverse_rnn.encode(data_reverse, data_length, seq_len)
+        hidden_reverse, _, _ = self.reverse_rnn.encode(data_reverse, data_length, seq_len, source, separator_id)
         # (seq_length, batch, cell_num_hidden)
         hidden_reverse = mx.sym.SequenceReverse(data=hidden_reverse, sequence_length=data_length,
                                                 use_sequence_length=True)

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -64,6 +64,7 @@ class ModelConfig(Config):
                  config_length_task: layers.LengthRatioConfig = None,
                  attention_monotonicity: Optional[str] = None,
                  attention_monotonicity_config_loss: Optional[loss.LossConfig] = None,
+                 separator_id: Optional[int] = None,
                  weight_tying: bool = False,
                  weight_tying_type: Optional[str] = C.WEIGHT_TYING_TRG_SOFTMAX,
                  weight_normalization: bool = False,
@@ -82,6 +83,7 @@ class ModelConfig(Config):
         self.config_length_task = config_length_task
         self.attention_monotonicity = attention_monotonicity
         self.attention_monotonicity_config_loss = attention_monotonicity_config_loss
+        self.separator_id = separator_id
         self.weight_tying = weight_tying
         self.weight_tying_type = weight_tying_type
         self.weight_normalization = weight_normalization

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -752,7 +752,8 @@ def create_model_config(args: argparse.Namespace,
                                      lhuc=args.lhuc is not None,
                                      num_pointers=num_pointers,
                                      attention_monotonicity=args.attention_monotonicity,
-                                     attention_monotonicity_config_loss=attention_monotonicity_config_loss)
+                                     attention_monotonicity_config_loss=attention_monotonicity_config_loss,
+                                     separator_id=separator_id)
     return model_config
 
 

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -171,7 +171,9 @@ class TrainingModel(model.SockeyeModel):
                 source_encoded_seq_len) = self.encoder.encode(source_embed,
                                                             source_embed_length,
                                                             source_embed_seq_len,
-                                                            get_pos_embed=False)
+                                                            get_pos_embed=False,
+                                                            source=source_words,
+                                                            separator_id=self.config.separator_id)
 
             # decoder
             # target_decoded: (batch-size, target_len, decoder_depth)


### PR DESCRIPTION
When flag `--ignore_prefix` is set, the positions for the positional encoding will be centered at the separator token. Any positions left of the separator token will get negative positions.

Example:

vanilla:
V  SG  3  PRS  <sep>  u  s  e
0   1    2     3        4       5  6 7 

separator-centered:
V  SG  3  PRS  <sep>  u  s  e
-4 -3 -2   -1        0       1  2  3 